### PR TITLE
Improved CMS fields for Robots.txt

### DIFF
--- a/code/pages/Site.php
+++ b/code/pages/Site.php
@@ -72,11 +72,9 @@ class Site extends Page implements HiddenClass, PermissionProvider {
 			new CheckboxField('IsDefault', _t(
 				'Multisites.ISDEFAULT', 'Is this the default site?'
 			)),
-            new HeaderField('RobotsTxtHeader', _t('Multisites.ROBOTSTXT', 'Robots.txt')),
-            new LiteralField('RobotsTxtUsage', _t('Multisites.ROBOTSTXTUSAGE',
-                '<p>Please consult <a href="http://www.robotstxt.org/robotstxt.html" target="_blank">http://www.robotstxt.org/robotstxt.html</a> for usage of the robots.txt file.</p>'
-            )),
-            new TextareaField('RobotsTxt', _t('Mulitsites.ROBOTSTXT', '&nbsp;'))
+			new HeaderField('SiteAdvancedHeader', _t('Multisites.SiteAdvancedHeader', 'Advanced Settings')),
+            		(new TextareaField('RobotsTxt', _t('Multisites.ROBOTSTXT', 'Robots.txt')))
+            			->setDescription(_t('Multisites.ROBOTSTXTUSAGE', '<p>Please consult <a href="http://www.robotstxt.org/robotstxt.html" target="_blank">http://www.robotstxt.org/robotstxt.html</a> for usage of the robots.txt file.</p>'))
 		)));
 
 		$devIDs = Config::inst()->get('Multisites', 'developer_identifiers');


### PR DESCRIPTION
Will create the following output:

![screenshot from 2015-10-07 16 20 49](https://cloud.githubusercontent.com/assets/186158/10343844/8ab31756-6d0f-11e5-90ba-405f62dd2195.png)

Which looks a lot nicer, especially if you add additional fields below it:

![screenshot from 2015-10-07 16 23 00](https://cloud.githubusercontent.com/assets/186158/10343868/b2468b22-6d0f-11e5-890b-9283e2064ed8.png)
