### PR TITLE
fix htmleditorfield content_css not getting set

### DIFF
--- a/code/extensions/MultisitesCmsMainExtension.php
+++ b/code/extensions/MultisitesCmsMainExtension.php
@@ -19,21 +19,19 @@ class MultisitesCMSMainExtension extends LeftAndMainExtension {
 	public function init(){
 		// set the htmleditor "content_css" based on the active site
 		$htmlEditorConfig = HtmlEditorConfig::get_active();
-		if(!$htmlEditorConfig->getOption('content_css')){
-			$site = Multisites::inst()->getActiveSite();
-			$theme = $site->getSiteTheme();
-			if($theme){
-				$cssFile = THEMES_DIR . "/$theme/css/editor.css";
-				if(file_exists(BASE_PATH . '/' . $cssFile)){
-					$htmlEditorConfig->setOption('content_css', $cssFile);
-					
-					if($this->owner->getRequest()->isAjax() && $this->owner->class == 'CMSPageEditController'){
-						// Add editor css path to header so javascript can update ssTinyMceConfig.content_css
-						$this->owner->getResponse()->addHeader('X-HTMLEditor_content_css', $cssFile);	
-					}
-					
-				}	
-			}
+		$site = Multisites::inst()->getActiveSite();
+		$theme = $site->getSiteTheme();
+		if($theme){
+			$cssFile = THEMES_DIR . "/$theme/css/editor.css";
+			if(file_exists(BASE_PATH . '/' . $cssFile)){
+				$htmlEditorConfig->setOption('content_css', $cssFile);
+				
+				if($this->owner->getRequest()->isAjax() && $this->owner->class == 'CMSPageEditController'){
+					// Add editor css path to header so javascript can update ssTinyMceConfig.content_css
+					$this->owner->getResponse()->addHeader('X-HTMLEditor_content_css', $cssFile);	
+				}
+				
+			}	
 		}
 	}
 


### PR DESCRIPTION
Not sure why we were checking if $htmlEditorConfig->getOption('content_css') had been set, it's always going to be set, meaning we never load the editor css for the the current site