### PR TITLE
persist active multisite in cms with session

### DIFF
--- a/code/extensions/MultisitesMemberExtension.php
+++ b/code/extensions/MultisitesMemberExtension.php
@@ -2,6 +2,7 @@
 class MultisitesMemberExtension extends DataExtension {
 	
 	public function memberLoggedIn(){
-		Session::clear('MultisitesModelAdmin_SiteID');
+		Session::clear('Multisites_ActiveSite');
+		Session::clear('MultisitesModelAdmin_SiteID'); // legacy
 	}
 }

--- a/code/extensions/MultisitesModelAdminExtension.php
+++ b/code/extensions/MultisitesModelAdminExtension.php
@@ -12,14 +12,14 @@ class MultisitesModelAdminExtension extends Extension {
 
 	
 	/**
-	 * If this dataClass is MultisitesAware, set the MultisitesModelAdmin_SiteID 
+	 * If this dataClass is MultisitesAware, set the Multisites_ActiveSite 
 	 * session variable to one of the follwing:
 	 * a) The current site, if the current member is a manager of that site
 	 * b) The first site that the current member is a manager of
 	 **/
 	public function onAfterInit(){	
 		if(singleton($this->owner->getList()->dataClass())->hasExtension('MultisitesAware')){
-			if(!Session::get('MultisitesModelAdmin_SiteID')){
+			if(!Session::get('Multisites_ActiveSite')){
 
 				$managedByMember = Multisites::inst()->sitesManagedByMember();
 				
@@ -30,7 +30,7 @@ class MultisitesModelAdminExtension extends Extension {
 					}else{
 						$siteID = $managedByMember[0];
 					}
-					Session::set('MultisitesModelAdmin_SiteID', $siteID);	
+					Multisites::inst()->setActiveSite($siteID);
 				}
 			}
 		}
@@ -38,14 +38,14 @@ class MultisitesModelAdminExtension extends Extension {
 
 	
 	/**
-	 * If this dataClass is MultisitesAware, filter the list by the current MultisitesModelAdmin_SiteID
+	 * If this dataClass is MultisitesAware, filter the list by the current Multisites_ActiveSite
 	 **/
 	public function updateList(&$list){
 		if(singleton($list->dataClass())->hasExtension('MultisitesAware')){
 			if($siteID = $this->owner->getRequest()->requestVar('SiteID')){
-				Session::set('MultisitesModelAdmin_SiteID', $siteID);		
+				Multisites::inst()->setActiveSite($siteID);
 			}
-			$list = $list->filter('SiteID', Session::get('MultisitesModelAdmin_SiteID'));
+			$list = $list->filter('SiteID', Multisites::inst()->getActiveSite());
 		}
 	}
 
@@ -81,7 +81,7 @@ class MultisitesModelAdminExtension extends Extension {
 					'SiteID', 
 					"Site: ", 
 					$source,
-					Session::get('MultisitesModelAdmin_SiteID')
+					Multisites::inst()->getActiveSite()->ID
 				));
 			}
 		}


### PR DESCRIPTION
In Mulitisites::getActiveSite(), we check CMSPageEditController::currentPage() to determine what site the user is editing. This fails if the request is to admin/pages/edit/EditorToolbar/viewfile?ID=XX because $controller->currentPage() will return an incorrect page based on the ID parameter in $_GET, that is used for a File in this case. 

This was causing major issues in the CMS when inserting images into the htmleditorfield on projects with more than 2 site themes.

Seeing as there is no way to get the current site id for requests to admin/pages/edit/EditorToolbar/viewfile?ID=XX, we now set a session variable in Multisites::getActiveSite(). I've updated the multisite model admin stuff to share the same session variable. So we now use the global Multisites_ActiveSite session variable instead of MultisitesModelAdmin_SiteID.