### PR TITLE
treat SiteTree objects as multisites aware in model admin

### DIFF
--- a/code/extensions/MultisitesModelAdminExtension.php
+++ b/code/extensions/MultisitesModelAdminExtension.php
@@ -25,7 +25,7 @@ class MultisitesModelAdminExtension extends Extension {
 	 * c) The first site that the current member is a manager of
 	 **/
 	public function onAfterInit(){	
-		if($this->getListDataClass()->hasExtension('MultisitesAware')){
+		if($this->modelIsMultiSitesAware()) {
 
 			if($siteID = $this->owner->getRequest()->requestVar('SiteID')){
 				$this->setActiveSite($siteID);
@@ -52,7 +52,7 @@ class MultisitesModelAdminExtension extends Extension {
 	 * If this dataClass is MultisitesAware, filter the list by the current Multisites_ActiveSite
 	 **/
 	public function updateList(&$list){
-		if($this->getListDataClass()->hasExtension('MultisitesAware')){
+		if($this->modelIsMultiSitesAware()){
 			$site = $this->getActiveSite();
 			if ($site) {
 				$list = $list->filter('SiteID', $site->ID);
@@ -65,7 +65,7 @@ class MultisitesModelAdminExtension extends Extension {
 	 * If the current member is not a "Manager" of any sites, they shouldn't be able to manage MultisitesAware DataObjects.
 	 **/
 	public function updateEditForm($form){
-		if($this->getListDataClass()->hasExtension('MultisitesAware')){
+		if($this->modelIsMultiSitesAware()) {
 			$managedSites = Multisites::inst()->sitesManagedByMember();
 			$source = Site::get()->filter('ID', Multisites::inst()->sitesManagedByMember())->map('ID', 'Title')->toArray();
 			$plural = singleton($this->owner->modelClass)->plural_name();
@@ -82,7 +82,7 @@ class MultisitesModelAdminExtension extends Extension {
 	 * Provide a Site filter
 	 **/
 	public function updateSearchForm($form){
-		if($this->getListDataClass()->hasExtension('MultisitesAware')){
+		if($this->modelIsMultiSitesAware()) {
 			$managedSites = Multisites::inst()->sitesManagedByMember();
 
 			$source = Site::get()->filter('ID', Multisites::inst()->sitesManagedByMember())->map('ID', 'Title')->toArray();
@@ -109,7 +109,7 @@ class MultisitesModelAdminExtension extends Extension {
 		if($this->owner->config()->use_active_site_session) {
 			return Multisites::inst()->getActiveSite();
 		} else {
-			if($this->getListDataClass()->hasExtension('MultisitesAware')) {
+			if($this->modelIsMultiSitesAware()) {
 				if($active = Session::get($this->getActiveSiteSessionKey())) {
 					return Site::get()->byID($active);
 				}
@@ -153,5 +153,16 @@ class MultisitesModelAdminExtension extends Extension {
 			$this->listDataClass = singleton($this->owner->getSearchContext()->getResults(array())->dataClass());
 		}		
 		return $this->listDataClass;
+	}
+
+
+	/**
+	 * Determines whether the current model being managed is MultiSitesAware
+	 *
+	 * @return boolean
+	 **/
+	private function modelIsMultiSitesAware() {
+		$model = $this->getListDataClass();
+		return $model->hasExtension('MultisitesAware') || $model->is_a('SiteTree');
 	}
 }


### PR DESCRIPTION
This is important for our current project - At the moment NewsAdmin displays pages from all sites. And creating a new NewsArticle in NewsAdmin displays an edit form that is customised based on the current site, without the user having any real say as to what the current site is. 

Having a Site filter on the list view for model admins managing SiteTree objects will make sure the user knows which site they are managing pages for. Especially if the model admin is set to use_active_site_session so that it filters by default (But I think it's best to leave that to the developer to do themselves so they have that control). 