### PR TITLE
fix(Site/PreviewPanel): DIsable preview panel so 'Split Mode' doesn't redirect the user to the /home/ page in SS 3.2+

### DIFF
--- a/code/extensions/MultisitesCmsMainExtension.php
+++ b/code/extensions/MultisitesCmsMainExtension.php
@@ -66,6 +66,20 @@ class MultisitesCMSMainExtension extends LeftAndMainExtension {
 		);
 	}
 
+	/**
+	 * If viewing 'Site', disable preview panel.
+	 */
+	public function updateEditForm($form) {
+        $classNameField = $form->Fields()->dataFieldByName('ClassName');
+        if ($classNameField) {
+            $className = $classNameField->Value();
+            if ($className === 'Site') 
+            {
+            	$form->Fields()->removeByName(array('SilverStripeNavigator'));
+                $form->removeExtraClass('cms-previewable');
+            }
+        }
+    }
 
 	/**
 	 * Adds a dropdown field to the search form to filter searches by Site


### PR DESCRIPTION
DIsable preview panel so 'Split Mode' doesn't redirect the user to the /home/ page in SS 3.2+

Resolves https://github.com/silverstripe-australia/silverstripe-multisites/issues/60
Which I kept hitting a lot. Also caused weird JS load errors when switching between any page and Site in some cases.