### PR TITLE
SS 3.1 / Multisites 1.2 -- FIX Remove editor_css swapover in admin interface

### DIFF
--- a/javascript/MultisitesAdmin.js
+++ b/javascript/MultisitesAdmin.js
@@ -1,21 +1,4 @@
 (function($){
-	$.entwine('ss', function($){
-
-		// check if the html editor config "content_css" needs to be updated 
-		// this will happen if the user has navigated to an area of the cms 
-		// associated with a different site than the screen they came from
-		$(document).ajaxComplete(function(e, xhr, settings) {
-			var editorCSS = xhr.getResponseHeader('X-HTMLEditor_content_css');
-			if(editorCSS){
-				if(editorCSS != ssTinyMceConfig.content_css ){
-					ssTinyMceConfig.content_css = editorCSS;
-					$('textarea.htmleditor').redraw();
-				}
-			}
-		});
-
-	});
-
 	//override getTreeConfig from CMSMain.Tree.js to allow context menu on "HiddenClass" page types (namely Site)
 	$.entwine('ss.tree', function($){
 		$('body .cms-tree').entwine({


### PR DESCRIPTION
Removed the editor_css swap for SS 3.1 / Multisites 1.2 as it caused problems in TinyMCE (Insert Media broke, Style dropdown appearing in odd places)