### PR TITLE
fix(requireDefaultRecords): Fix bug where default pages like Home Page, About Us and error pages wouldn't be created on new sites.

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -27,8 +27,6 @@ CMSMenu::remove_menu_item('MultisitesCMSPageAddController');
 LeftAndMain::require_css(MULTISITES_PATH . '/css/MultisitesAdmin.css');
 LeftAndMain::require_javascript(MULTISITES_PATH . '/javascript/MultisitesAdmin.js');
 
-SiteTree::set_create_default_pages(false);
-
 // Remove LeftAndMain.AddForm.js - at least until this ticket is resolved
 // http://open.silverstripe.org/ticket/7987
 Requirements::block(FRAMEWORK_ADMIN_DIR . '/javascript/LeftAndMain.AddForm.js');

--- a/code/extensions/MultisitesControllerExtension.php
+++ b/code/extensions/MultisitesControllerExtension.php
@@ -10,6 +10,18 @@ class MultisitesControllerExtension extends Extension {
 	 * Sets the theme to the current site theme
 	 **/
 	public function onAfterInit() {
+		if ($this->owner instanceof DatabaseAdmin) {
+			//
+			// 2016-12-16 -	This is disabled in sitetree.yml to stop users placing
+			//				pages above a Site. However, during dev/build we don't
+			//				want pages validated so they can be placed top-level, and
+			//				then be moved underneath Site during it's
+			//				requireDefaultRecords() call.
+			//
+			SiteTree::config()->can_be_root = true;
+			return;
+		}
+
 		if ($this->owner instanceof DevelopmentAdmin ||
 			$this->owner instanceof DevBuildController ||
 			$this->owner instanceof DatabaseAdmin) {


### PR DESCRIPTION
fix(requireDefaultRecords): Fix bug where default pages like Home Page, About Us and error pages wouldn't be created on new sites.

Resolves the unclear issue here: https://github.com/silverstripe-australia/silverstripe-multisites/pull/64